### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: "ruby test_data.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "stringex"
+gem "minitest"


### PR DESCRIPTION
This PR adds a `.travis.yml` file in order to have a CI on travis-ci.org for all PR branches.

It also fixes the testing dependencies in the `Gemfile`.

_edit_: travis-ci.org is a Continious Integration service. With this simple file, we will be able to have the tests launched automatically on each PR and have the status reported there.

