### PR TITLE
add Gemfile.lock and specify gems versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: ruby
-script: "ruby test_data.rb"
+script: "bundle exec ruby test_data.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "stringex"
-gem "minitest"
+gem "stringex", "~> 2.5.2"
+gem "minitest", "~> 5.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.6.0)
+    stringex (2.5.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest (~> 5.6.0)
+  stringex (~> 2.5.2)


### PR DESCRIPTION
From Bundler's [top page](http://bundler.io/):

> [...] adds the Gemfile and Gemfile.lock to your repository. This ensures that other developers on your app, as well as your deployment environment, will all use the same third-party code that you are using now.

It is also considered good practice to specify gem version numbers up to the minor one. I used the "~>" operator here to allow for bugfix releases when running `bundle update`